### PR TITLE
Fix bug of only one rocket existing in the game

### DIFF
--- a/a3/Client.js
+++ b/a3/Client.js
@@ -79,7 +79,7 @@ function Client() {
                     } 
                     var r = new Rocket();
                     r.init(message.x, message.y, message.dir, sid);
-                    rockets[rid.rocket] = r;
+                    rockets[rid] = r;
                     break;
                 case "hit":
                     // Rocket rid just hit Ship rid


### PR DESCRIPTION
While trying out the latest version of the code, I realized there can be only one instance of a rocket in the entire game. If I shot another rocket, the existing rocket in the game will be destroyed, which had a  different behaviour from the version we tried during lesson. 

Upon inspection, I found that in `Client.js`, the bug is in the line `rockets[rid.rocket] = r;`. `rid` is an integer, not an object, hence it does not have a property called `rocket`. After changing that line to `rockets[rid] = r;`, the game worked well.

Please verify! (:
