### PR TITLE
Add break after "delete" command

### DIFF
--- a/a3/Client.js
+++ b/a3/Client.js
@@ -114,6 +114,7 @@ function Client() {
                     } else {
                         delete ships[id];
                     }
+                    break;
                 default:
                     console.log("error: undefined command " + message.type);
             }


### PR DESCRIPTION
`error: undefined command delete` is shown in the browser console when a user leaves the game. This is due to a missing `break` statement in the `case "delete"`, which causes execution to fallthrough into the `default:`branch after a `"delete"` message.
